### PR TITLE
Remove quiet CLI option

### DIFF
--- a/lib/racker/cli.rb
+++ b/lib/racker/cli.rb
@@ -41,8 +41,8 @@ module Racker
       logger.debug('Processing complete.')
 
       # Thats all folks!
-      puts "Processing complete!" unless options[:quiet]
-      puts "Packer file generated: #{options[:output]}" unless options[:quiet]
+      logger.debug("Processing complete!\n")
+      logger.debug("Packer file generated: #{options[:output]}")
 
       return 0
     end
@@ -55,7 +55,6 @@ module Racker
         knockout:      '~~',
         output:        '',
         templates:     [],
-        quiet:         false,
       }
     end
 
@@ -69,10 +68,6 @@ module Racker
 
         opts.on('-k', '--knockout PREFIX', 'Set the knockout prefix (Default: ~~)') do |v|
           options[:knockout] = v || '~~'
-        end
-
-        opts.on('-q', '--quiet', 'Disable unnecessary output') do |v|
-          options[:quiet] = true
         end
 
         opts.on_tail('-h', '--help', 'Show this message') do

--- a/lib/racker/processor.rb
+++ b/lib/racker/processor.rb
@@ -74,7 +74,7 @@ module Racker
     def load(templates)
       return capture_templates do
         templates.each do |template|
-          puts "Loading template file: #{template}" unless @options[:quiet]
+          logger.debug("Loading template file: #{template}")
           Kernel.load template
         end
       end

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Racker::Processor do
 
   context '#capture_templates' do
     before(:all) do
-      @instance = described_class.new(:quiet => true)
+      @instance = described_class.new({})
     end
 
     it 'captures [version, template_proc] pairs for each call to ::register_template' do
@@ -59,7 +59,6 @@ RSpec.describe Racker::Processor do
       @options = {
         :output => "/tmp/#{SecureRandom.uuid}/this_directory_should_not_exist/template.json",
         :knockout => '~~',
-        :quiet => true,
       }
       @output_path = @options[:output]
       @instance = described_class.new(@options)
@@ -124,7 +123,6 @@ RSpec.describe Racker::Processor do
 
       @options.replace({
         :output => @output_path,
-        :quiet => true,
         :templates => [
           fixture_path('low_priority_template.rb'),
         ],
@@ -151,30 +149,9 @@ RSpec.describe Racker::Processor do
       @instance = described_class.new(@options)
     end
 
-    it 'puts the template file if a falsy :quiet option was provided' do
-      expect(@instance).to receive(:puts).exactly(3).times
-
-      @options.delete(:quiet)
-      @instance.load([@fixture])
-      @options[:quiet] = nil
-      @instance.load([@fixture])
-      @options[:quiet] = false
-      @instance.load([@fixture])
-    end
-
-    it 'puts no output if a truthy :quiet option was provided' do
-      expect(@instance).to_not receive(:puts)
-
-      @options[:quiet] = true
-      @instance.load([@fixture])
-      @options[:quiet] = Object.new
-      @instance.load([@fixture])
-    end
-
     it 'loads each given template path' do
       expect(Kernel).to receive(:load).with(@fixture).exactly(3).times
 
-      @options[:quiet] = true
       @instance.load([
         @fixture,
         @fixture,


### PR DESCRIPTION
Builds on #3 and #4 to remove the quiet option from the CLI interface.

I may be pushing my luck here, but to give you some sense of my vision, I'd like to see racker support multiple Writer adapters.

Right now, the only Writer adapter in racker is hardcoded into `Racker::Processer#execute!` and it writes the compiled JSON to an output file, and in this case `puts`-ing to STDOUT is fine. However, one of the other Writer adapters I am interested in would allow for writing the compiled JSON to STDOUT, in which case invocations of `puts` are going to cause weird noise.

Ultimately, I don't think `puts`-ing has to be entirely removed, but it should not be invoked by the core of Racker. This would allow for a FileWriter that could still be verbose while an StdOutWriter could rely solely on the logs for communicating events.

An alternative option would be to make it so the usage of some Writers forced the quiet flag, but that seems inconsistent and kind of contrary to [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). Another alternative might be to replace the quiet flag with a verbose flag, and default to silence. It's also not unreasonable to relegate all feedback to the log.

My goal in adding a StdOutWriter would be to make it unnecessary to materialize intermediary json templates by making something like the following possible:

``` bash
$ racker template1.rb template2.rb - | packer build -
```

It would also reduces the number of Writer specific conditionals that would be required in the internals of `Racker::Processor#execute!` to make such a change possible.

Definitely open to feedback on other ways to approach making this happen.
